### PR TITLE
Improve grammar / formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # armory_templates
 
-Templates to accompany Armory SDK. Check out the [manual](https://github.com/armory3d/armory/wiki).
+Here are some basic templates to compliment the [Armory SDK](https://github.com/armory3d/armsdk/releases).<br />
+Check out the official [Armory Manual](https://github.com/armory3d/armory/wiki).
 
-Note: Download the package from [releases](https://github.com/armory3d/armory_templates/releases). Only use the latest revision of this repository if you are using [git Armory](https://github.com/armory3d/armory/wiki/gitversion).
+**Note:** Download the last stable, templates package from [here](https://github.com/armory3d/armory_templates/releases).<br />
+Only use the latest revision of this repository if you're using [GIT Armory](https://github.com/armory3d/armory/wiki/gitversion).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # armory_templates
 
-Here are some basic templates to compliment the [Armory SDK](https://github.com/armory3d/armsdk/releases).<br />
+Here are some basic templates to complement the [Armory SDK](https://github.com/armory3d/armsdk/releases).<br />
 Check out the official [Armory Manual](https://github.com/armory3d/armory/wiki).
 
 **Note:** Download the last stable, templates package from [here](https://github.com/armory3d/armory_templates/releases).<br />


### PR DESCRIPTION
Improved grammar / formatting.

Fixed small typo:
"accompany," means, "to go with."

The templates do not ship with the armsdk; at least no longer, which means this information is incorrect or outdated.